### PR TITLE
remove trait icon from header

### DIFF
--- a/goci-interfaces/goci-ui/src/main/resources/templates/efotrait-page.html
+++ b/goci-interfaces/goci-ui/src/main/resources/templates/efotrait-page.html
@@ -47,9 +47,6 @@
     <div class="container-fluid clearfix">
         <div class="col-xs-12 col-md-12 col-xs-12 col-xs-12">
             <h2 style="margin:0px">
-                <img alt="externalLink"
-                     style="width: 1em; height: auto;"
-                     th:src="@{/icons/GWAS_trait_2017.png}"/>
                 <span style="padding-left:5px">Trait: </span>
                 <span id="top-panel-trait-label" th:text="${result.query}" style="padding-left:5px"></span>
             </h2>


### PR DESCRIPTION
The Trait page icon in the header should have been removed, but in the merge the original code was accepted.
