### PR TITLE
add traits to variant information panel

### DIFF
--- a/goci-interfaces/goci-ui/src/main/resources/static/js/variantresult.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/variantresult.js
@@ -161,6 +161,7 @@ function getVariantInfo(data,rsId) {
     var genes_mapped_url = [];
     var traits_reported = [];
     var traits_reported_url = [];
+    var all_mapped_traits = [];
     $.each(data, function (index, doc) {
         // Mapped genes
         if (doc.hasOwnProperty('entrezMappedGenes')) {
@@ -173,6 +174,58 @@ function getVariantInfo(data,rsId) {
                 }
             });
         }
+
+        // Mapped Traits
+        var mapped_traits = doc.mappedLabel;
+        if (doc.hasOwnProperty('entrezMappedGenes')) {
+            $.each(mapped_traits, function(index, mapped_trait) {
+                var link = gwasProperties.contextPath + 'efotraits/' + doc.mappedUri[index].split('/').slice(-1)[0];
+                mapped_traits[index] = setInternalLinkText(link, mapped_trait);
+                // add unique traits only
+                if (jQuery.inArray(mapped_traits[index], all_mapped_traits) == -1) {
+                    all_mapped_traits.push(mapped_traits[index]);
+                }
+            });
+        }
+        // sort multi-word traits in alphabetical order
+        all_mapped_traits.sort(function(a,b) {
+            // extract trait label from URL
+            var a_first_word_index = parseInt(a.indexOf(">")) + 1;
+            var a_last_word_index = a.indexOf("</a>");
+            var a_words = a.slice(a_first_word_index, a_last_word_index).toLowerCase();
+
+            var b_first_word_index = parseInt(b.indexOf(">")) + 1;
+            var b_last_word_index = b.indexOf("</a>");
+            var b_words = b.slice(b_first_word_index, b_last_word_index).toLowerCase();
+
+            // find shortest trait label
+            var shortest_trait_label;
+            if (a_words.split(' ').length < b_words.split(' ').length) {
+                shortest_trait_label = a_words.split(' ').length;
+            } else {
+                shortest_trait_label = b_words.split(' ').length;
+            }
+
+            // find word index in trait label to compare for alphabetical ordering, some traits
+            // start with the same word, e.g. coronary artery disease vs. coronary heart disease
+            for (var i = 0; i < shortest_trait_label; i++) {
+                if (a_words.split(' ')[i] == b_words.split(' ')[i]) {
+                    continue;
+                }
+                else {
+                    break;
+                }
+            }
+
+            if (a_words.split(' ')[i] < b_words.split(' ')[i]) {
+                return -1;
+            }
+            if (a_words.split(' ')[i] > b_words.split(' ')[i]) {
+                return 1;
+            }
+            return 0;
+        });
+        $("#traits").html(all_mapped_traits.join(', '));
 
         // Reported traits
         var traits = [];
@@ -190,7 +243,7 @@ function getVariantInfo(data,rsId) {
     genes_mapped_url.sort();
     traits_reported_url.sort();
 
-    // Traits display
+    // Reported Traits display
     if (traits_reported.length <= list_min) {
         $("#variant-traits").html(traits_reported_url.join(', '));
     }
@@ -309,6 +362,14 @@ function setQueryUrl(query, label) {
         label = query;
     }
     return '<a href="'+gwasProperties.contextPath+'search?query='+query+'">'+label+'</a>';
+}
+
+// Generate an internal link to page
+function setTraitPageUrl(query, label) {
+    if (!label) {
+        label = query;
+    }
+    return '<a href="'+gwasProperties.contextPath+'efotraits/'+query+'">'+label+'</a>';
 }
 
 // Update the display of the variant functional class

--- a/goci-interfaces/goci-ui/src/main/resources/templates/variant-page.html
+++ b/goci-interfaces/goci-ui/src/main/resources/templates/variant-page.html
@@ -115,6 +115,12 @@
                         </div>
                         <div class="clearfix">
                             <div class="col-lg-4 col-md-5 col-sm-5 col-xs-5 item-left">
+                                <span class="item-left-bold">Trait(s)</span>
+                            </div>
+                            <div class="col-lg-8 col-md-7 col-sm-7 col-xs-7" id="traits">-</div>
+                        </div>
+                        <div class="clearfix">
+                            <div class="col-lg-4 col-md-5 col-sm-5 col-xs-5 item-left">
                                 <span>Reported trait(s)</span>
                                 <span class="glyphicon glyphicon-question-sign" data-toggle="tooltip" title="Detailed study-level trait descriptions associated with this variant, taking into account the study design"></span>
                             </div>


### PR DESCRIPTION
Add list of traits, in alphbetical order with links to their respective trait page, to the Variant information panel.

Test cases: 
http://localhost:8080/gwas-ui/variants/rs149232047
http://localhost:8080/gwas-ui/variants/rs10771399
http://localhost:8080/gwas-ui/variants/rs10455872
