### PR TITLE
change default display columns

### DIFF
--- a/goci-interfaces/goci-ui/src/main/resources/static/js/common-datatables/studies-datatable.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/common-datatables/studies-datatable.js
@@ -223,25 +223,23 @@ function displayDatatableStudies(data, PAGE_TYPE, cleanBeforeInsert=true) {
             field: 'initial_sample_text',
             title: 'Discovery sample description',
             sortable: true,
-            visible: defaultVisible,
+            visible:  false,
             filterControl: 'input'
         }, {
             field: 'replicate_sample_text',
             title: 'Replication sample description',
             sortable: true,
-            visible: defaultVisible,
+            visible: false,
             filterControl: 'input'
         }, {
             field: 'initial_ancestral_links_text',
             title: 'Discovery sample number and ancestry',
             sortable: true,
-            visible: defaultNotVisible,
             filterControl: 'input'
         }, {
             field: 'replicate_ancestral_links_text',
             title: 'Replication sample number and ancestry',
             sortable: true,
-            visible: defaultNotVisible,
             filterControl: 'input'
         }, {
             field: 'nr_associations',


### PR DESCRIPTION
All study tables should display “Sample number and ancestry” on all pages. “Sample description” should be an optional column on all pages.