### PR TITLE
When formatting data for data tables, and excessive space is removed

### DIFF
--- a/goci-interfaces/goci-ui/src/main/resources/static/js/common-datatables/associations-datatable.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/common-datatables/associations-datatable.js
@@ -43,6 +43,10 @@ function displayDatatableAssociations(data, cleanBeforeInsert) {
 
             // Risk allele
             var riskAllele = asso.strongestAllele[0];
+
+            // This line will remove the space from the risk allele (see GOCI-2480)
+            riskAllele = riskAllele.replace(" -", "-")
+
             // there may be more than one riskAllele value
             var riskAlleles = riskAllele.split(";");
 


### PR DESCRIPTION
When formatting data for data tables, and excessive space is removed from the snp-risk allele to prevent breaking the code. It's just one line in the associations-datatable.js which might be removed once the curation interface is supplied with the extra check to prevent the addition of the variants with spaces.