### PR TITLE
Goci 2436 tw variant page missing info

### DIFF
--- a/goci-interfaces/goci-ui/src/main/resources/static/js/variantresult.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/variantresult.js
@@ -199,7 +199,7 @@ function getVariantInfo(data,rsId) {
 
         // Mapped Traits
         var mapped_traits = doc.mappedLabel;
-        if (doc.hasOwnProperty('entrezMappedGenes')) {
+        if (doc.mappedLabel) {
             $.each(mapped_traits, function(index, mapped_trait) {
                 var link = gwasProperties.contextPath + 'efotraits/' + doc.mappedUri[index].split('/').slice(-1)[0];
                 mapped_traits[index] = setInternalLinkText(link, mapped_trait);
@@ -266,25 +266,51 @@ function getVariantInfo(data,rsId) {
     traits_reported_url.sort();
 
     // Reported Traits display
-    if (traits_reported.length <= list_min) {
-        $("#variant-traits").html(traits_reported_url.join(', '));
+    if (jQuery.isEmptyObject(traits_reported_url)){
+        $("#variant-traits-label").hide();
     }
     else {
-        $("#variant-traits").html(longContentList("gwas_traits_div",traits_reported_url,'traits'));
+        if (traits_reported.length <= list_min) {
+            $("#variant-traits").html(traits_reported_url.join(', '));
+        }
+        else {
+            $("#variant-traits").html(longContentList("gwas_traits_div", traits_reported_url, 'traits'));
+        }
     }
 
-    if (typeof location == 'undefined') {
+    // Location
+    if (jQuery.type(location) == 'undefined') {
         $("#variant-location").html('Variant does not map to the genome');
     }
     else {
         $("#variant-location").html(location);
     }
 
-    $("#variant-region").html(region);
-    if (func) {
+    // Cytogenetic region
+    if (jQuery.type(region) == 'undefined') {
+        $("#variant-region-label").hide();
+    }
+    else {
+        $("#variant-region").html(region);
+    }
+
+    // Most severe consequence
+    if (jQuery.type(func) == 'undefined') {
+        $("#variant-class-label").hide();
+    }
+    else {
         $("#variant-class").html(variationClassLabel(func));
     }
-    $("#variant-mapped-genes").html(genes_mapped_url.join(', '));
+
+    // Mapped genes
+    if (jQuery.isEmptyObject(genes_mapped_url)) {
+        $("#variant-mapped-genes-label").hide();
+    }
+    else {
+        $("#variant-mapped-genes").html(genes_mapped_url.join(', '));
+    }
+
+
     $("#variant-summary-content").html(getSummary(data));
 }
 
@@ -485,8 +511,17 @@ function getVariantInfoFromEnsembl(rsId) {
             .done(function(data) {
                 console.log(data);
                 processVariantInfoFromEnsembl(rsId,data);
+            })
+            .fail(function() {
+                hideLabels();
             });
     console.log("Ensembl REST query done to retrieve variant information");
+}
+
+function hideLabels () {
+    $("#variant-alleles-label").hide();
+    $("#minor-allele-label").hide();
+    $("#minor-allele-freq-label").hide();
 }
 
 function processVariantInfoFromEnsembl(rsId, data) {

--- a/goci-interfaces/goci-ui/src/main/resources/static/js/variantresult.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/variantresult.js
@@ -50,7 +50,7 @@ function getDataSolr(main, initLoad=false) {
         console.log("Solr research done for " + searchQuery);
         return data;
     }).catch(function(err) {
-        console.error('Error when seaching solr for' + searchQuery + '. ' + err);
+        console.error('Error when searching solr for' + searchQuery + '. ' + err);
         throw(err);
     })
     
@@ -251,7 +251,7 @@ function getVariantInfo(data,rsId) {
 
         // Reported traits
         var traits = [];
-        if (doc.hasOwnProperty('entrezMappedGenes')) {
+        if (doc.traitName) {
             $.each(doc.traitName, function(index, trait) {
                 if (jQuery.inArray(trait, traits_reported) == -1) {
                     traits_reported.push(trait);
@@ -266,16 +266,11 @@ function getVariantInfo(data,rsId) {
     traits_reported_url.sort();
 
     // Reported Traits display
-    if (jQuery.isEmptyObject(traits_reported_url)){
-        $("#variant-traits-label").hide();
+    if (traits_reported.length <= list_min) {
+        $("#variant-traits").html(traits_reported_url.join(', '));
     }
     else {
-        if (traits_reported.length <= list_min) {
-            $("#variant-traits").html(traits_reported_url.join(', '));
-        }
-        else {
-            $("#variant-traits").html(longContentList("gwas_traits_div", traits_reported_url, 'traits'));
-        }
+        $("#variant-traits").html(longContentList("gwas_traits_div", traits_reported_url, 'traits'));
     }
 
     // Location
@@ -287,29 +282,17 @@ function getVariantInfo(data,rsId) {
     }
 
     // Cytogenetic region
-    if (jQuery.type(region) == 'undefined') {
-        $("#variant-region-label").hide();
-    }
-    else {
-        $("#variant-region").html(region);
-    }
+    $("#variant-region").html(region);
 
     // Most severe consequence
-    if (jQuery.type(func) == 'undefined') {
-        $("#variant-class-label").hide();
-    }
-    else {
+    if (func) {
         $("#variant-class").html(variationClassLabel(func));
     }
 
     // Mapped genes
-    if (jQuery.isEmptyObject(genes_mapped_url)) {
-        $("#variant-mapped-genes-label").hide();
-    }
-    else {
+    if (genes_mapped_url.length != 0) {
         $("#variant-mapped-genes").html(genes_mapped_url.join(', '));
     }
-
 
     $("#variant-summary-content").html(getSummary(data));
 }
@@ -513,15 +496,9 @@ function getVariantInfoFromEnsembl(rsId) {
                 processVariantInfoFromEnsembl(rsId,data);
             })
             .fail(function() {
-                hideLabels();
+                console.log('Call failed')
             });
     console.log("Ensembl REST query done to retrieve variant information");
-}
-
-function hideLabels () {
-    $("#variant-alleles-label").hide();
-    $("#minor-allele-label").hide();
-    $("#minor-allele-freq-label").hide();
 }
 
 function processVariantInfoFromEnsembl(rsId, data) {

--- a/goci-interfaces/goci-ui/src/main/resources/templates/variant-page.html
+++ b/goci-interfaces/goci-ui/src/main/resources/templates/variant-page.html
@@ -92,34 +92,34 @@
                             </div>
                             <div class="col-lg-8 col-md-7 col-sm-7 col-xs-7" id="variant-location">-</div>
                         </div>
-                        <div class="clearfix">
+                        <div class="clearfix" id="variant-region-label">
                             <div class="col-lg-4 col-md-5 col-sm-5 col-xs-5 item-left">
                                 <span>Cytogenetic region</span>
                                 <span class="glyphicon glyphicon-question-sign" data-toggle="tooltip" title="Cytogenetic band corresponding to the genomic location"></span>
                             </div>
                             <div class="col-lg-8 col-md-7 col-sm-7 col-xs-7" id="variant-region">-</div>
                         </div>
-                        <div class="clearfix">
+                        <div class="clearfix" id="variant-class-label">
                             <div class="col-lg-4 col-md-5 col-sm-5 col-xs-5 item-left">
                                 <span>Most severe consequence</span>
                                 <span class="glyphicon glyphicon-question-sign" data-toggle="tooltip" title="Most severe consequence of the variant on the overlapping transcript(s)"></span>
                             </div>
                             <div class="col-lg-8 col-md-7 col-sm-7 col-xs-7" id="variant-class">-</div>
                         </div>
-                        <div class="clearfix">
+                        <div class="clearfix" id="variant-mapped-genes-label">
                             <div class="col-lg-4 col-md-5 col-sm-5 col-xs-5 item-left">
                                 <span>Mapped gene(s)</span>
                                 <span class="glyphicon glyphicon-question-sign" data-toggle="tooltip" title="Gene(s) overlapping the variant. If a variant is intergenic, the closest 5' and 3' genes are listed"></span>
                             </div>
                             <div class="col-lg-8 col-md-7 col-sm-7 col-xs-7" id="variant-mapped-genes">-</div>
                         </div>
-                        <div class="clearfix">
+                        <div class="clearfix" id="traits-label">
                             <div class="col-lg-4 col-md-5 col-sm-5 col-xs-5 item-left">
                                 <span class="item-left-bold">Trait(s)</span>
                             </div>
                             <div class="col-lg-8 col-md-7 col-sm-7 col-xs-7" id="traits">-</div>
                         </div>
-                        <div class="clearfix">
+                        <div class="clearfix" id="variant-traits-label">
                             <div class="col-lg-4 col-md-5 col-sm-5 col-xs-5 item-left">
                                 <span>Reported trait(s)</span>
                                 <span class="glyphicon glyphicon-question-sign" data-toggle="tooltip" title="Detailed study-level trait descriptions associated with this variant, taking into account the study design"></span>
@@ -130,21 +130,21 @@
 
                     <!-- Ensembl data -->
                     <div class="panel-body col-lg-5 col-md-4 col-sm-4 col-xs-4">
-                        <div class="clearfix">
+                        <div class="clearfix" id="variant-alleles-label">
                             <div class="col-lg-3 col-md-4 col-sm-4 col-xs-4 item-left">
                                 <span>Alleles</span>
                                 <span class="glyphicon glyphicon-question-sign" data-toggle="tooltip" title="Reference allele / alternative allele(s)"></span>
                             </div>
                             <div class="col-lg-9 col-md-8 col-sm-8 col-xs-8" id="variant-alleles">-</div>
                         </div>
-                        <div class="clearfix">
+                        <div class="clearfix" id="minor-allele-label">
                             <div class="col-lg-3 col-md-4 col-sm-4 col-xs-4 item-left">
                                 <span>Minor allele</span>
                                 <span class="glyphicon glyphicon-question-sign" data-toggle="tooltip" title="Second most frequent allele in the 1000 Genomes Phase 3 combined population"></span>
                             </div>
                             <div class="col-lg-9 col-md-8 col-sm-8 col-xs-8" id="minor-allele">-</div>
                         </div>
-                        <div class="clearfix">
+                        <div class="clearfix" id="minor-allele-freq-label">
                             <div class="col-lg-3 col-md-4 col-sm-4 col-xs-4 item-left">
                                 <span>MAF</span>
                                 <span class="glyphicon glyphicon-question-sign" data-toggle="tooltip" title="Minor allele frequency in the 1000 Genomes Phase 3 combined population"></span>


### PR DESCRIPTION
This work is to address: https://www.ebi.ac.uk/panda/jira/browse/GOCI-2512 where the trait(s) and reported trait(s) are not displayed for non-mapped variants.

This bug was partially fixed while working on GOCI-2436 so I used the existing branch with this work in progress. Note, the code to hide the display of fields without values was originally requested, but then the feature changed and this was no longer needed. 

Here are a few example variants for testing to confirm the trait(s) and reported trait(s) are displayed:
- 1kg_6_30260446
- rs687621
- kgp10769919 
- rs7329174

