### PR TITLE
Goci 2522 ds hotfix

### DIFF
--- a/goci-interfaces/goci-ui/src/main/resources/static/js/resultexpansion.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/resultexpansion.js
@@ -330,14 +330,6 @@ function addResults(data, expand, id) {
                         var geneDescription = '' // initializing empty description
                         var querySting = $('#query').text().toUpperCase()
 
-                        // Checking if the queried term is not the same as the title:
-                        if ( doc.title != querySting){
-                            console.log("[Info] The queried string is different from the gene symbol..." + querySting +" vs. " + doc.title)
-                            // Checking for synonyms:
-                            if (doc.synonymsGene.match(querySting)){
-                                geneDescription += "<i>" + querySting + " is a synonym for " + doc.title + "</i><br>"
-                            }
-                        }
                         var descriptionElements = descriptionTruncated.split("|");
                         geneDescription += "<b>Description: </b>"+descriptionElements[0] +
                             "<br><b>Genomic location: </b>" + descriptionElements[1] +

--- a/goci-interfaces/goci-ui/src/main/resources/static/js/resultexpansion.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/resultexpansion.js
@@ -328,7 +328,6 @@ function addResults(data, expand, id) {
                     // Add custom formatting for gene description
                     if (doc.resourcename == "gene") {
                         var geneDescription = '' // initializing empty description
-                        var querySting = $('#query').text().toUpperCase()
 
                         var descriptionElements = descriptionTruncated.split("|");
                         geneDescription += "<b>Description: </b>"+descriptionElements[0] +

--- a/goci-interfaces/goci-ui/src/main/resources/static/js/solrsearch.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/solrsearch.js
@@ -338,15 +338,6 @@ function processData(data) {
                     var variantDescription = '' // initializing empty description
                     var querySting = $('#query').text().toUpperCase()
 
-                    // Checking if the queried term is not the same as the title:
-                    if ( doc.title != $('#query').text().toUpperCase()){
-                        console.log("[Info] The queried string is different from the gene symbol...")
-                        // Checking for synonyms:
-                        if (doc.synonymsGene.match(querySting)){
-                            variantDescription += "<i>" + querySting + " is a synonym for " + doc.title + "</i><br>"
-                        }
-                    }
-
                     var descriptionElements = descriptionTruncated.split("|");
                     variantDescription += "<b>Description: </b>"+descriptionElements[0] +
                         "<br><b>Genomic location: </b>" + descriptionElements[1] +

--- a/goci-interfaces/goci-ui/src/main/resources/static/js/solrsearch.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/solrsearch.js
@@ -336,7 +336,6 @@ function processData(data) {
                 // Add custom formatting for gene description
                 if (doc.resourcename == "gene") {
                     var variantDescription = '' // initializing empty description
-                    var querySting = $('#query').text().toUpperCase()
 
                     var descriptionElements = descriptionTruncated.split("|");
                     variantDescription += "<b>Description: </b>"+descriptionElements[0] +


### PR DESCRIPTION
After a generic search (*) that returns all documents from the slim solr, users could not narrow down the list to genes. I have removed a piece of code which was trying to find out which field does match with the query as we no longer support search in gene synonyms. 