### PR TITLE
Goci 2541 special character fix

### DIFF
--- a/goci-interfaces/goci-ui/src/main/resources/static/js/solrsearch.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/solrsearch.js
@@ -140,22 +140,23 @@ function solrSearch(queryTerm) {
         var boost_field = ' OR title:"'.concat(queryTerm).concat('"')+' OR synonyms:"'.concat(queryTerm).concat('"');
         var searchPhrase = searchTerm.concat(boost_field)
     }
-    else if(queryTerm.indexOf(':') != -1 && queryTerm.indexOf('-') != -1){
+    else if(queryTerm.match(/[XY0-9]\:[0-9]+-[0-9]+/gi)){
         var elements = queryTerm.split(':');
-        var chrom = elements[0].trim();
-        if(chrom == 23){
-            chrom = 'X'
-        }
+
+        // suitable for chr#: and #: as well:
+        var chrom = elements[0].trim().toUpperCase().replace("CHR","");
+
+        // We don't check if the submitted chromosome valid or not. We should though.
+        // We need to test if the start position is smaller than the end.
         var bp1 = elements[1].split('-')[0].trim();
         var bp2 = elements[1].split('-')[1].trim();
 
         // Returning variants based on coordinates:
-        // var searchPhrase = 'chromosomeName:'.concat(chrom).concat(' AND chromosomePosition:[').concat(bp1).concat(' TO ').concat(bp2).concat(']');
         var searchPhrase = "chromosomeName: "+chrom+" AND ( chromosomePosition:[ "+bp1+" TO "+bp2+" ] OR chromosomeEnd : [ "+bp1+" TO "+bp2+" ] OR chromosomeStart : [ "+bp1+" TO "+bp2+" ] )"
-
     }
     else {
         var searchTerm = 'text:"'.concat(queryTerm).concat('"');
+
         // Search using title field also in query
         var boost_field = ' OR title:"'.concat(queryTerm).concat('"')+' OR synonyms:"'.concat(queryTerm).concat('"');
         var searchPhrase = searchTerm.concat(boost_field);

--- a/goci-interfaces/goci-ui/src/main/resources/static/js/variantresult.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/variantresult.js
@@ -34,7 +34,7 @@ function getDataSolr(main, initLoad=false) {
     console.log("Solr research request received for " + searchQuery);
     return promisePost( gwasProperties.contextPath + 'api/search/advancefilter',
         {
-            'q': searchQuery,
+            'q': '"' + searchQuery + '"' ,
             'max': 99999,
             'group.limit': 99999,
             'group.field': 'resourcename',


### PR DESCRIPTION
We have noticed that certain variants with special characters mess up the search interface and the variant page. This branch fixes that issue. There are two points where modifications were made:

1) *solrsearch.js* - proper parsing of chromosomes position. The old interface considers  **HLA-B*57:01** as a genomic location as the string contains a dash and a colon. 
2) *variantresult.js* - query string is quoted to make sure solr won't translates special characters in **HLA-B*57:01**