### PR TITLE
remove multiple sort option from association data table

### DIFF
--- a/goci-interfaces/goci-ui/src/main/resources/templates/fragments/association-datatable.html
+++ b/goci-interfaces/goci-ui/src/main/resources/templates/fragments/association-datatable.html
@@ -26,7 +26,7 @@
                    data-export-types="['csv']"
                    data-search="true"
                    data-show-columns="true"
-                   data-show-multi-sort="true"
+                   data-show-multi-sort="false"
                    data-icons="icons"
                    data-filter-control="true">
             </table>


### PR DESCRIPTION
This update removes the multiple sort icon from the Association data table.