### PR TITLE
add help icon to publication date column

### DIFF
--- a/goci-interfaces/goci-ui/src/main/resources/static/js/common-datatables/studies-datatable.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/common-datatables/studies-datatable.js
@@ -175,6 +175,9 @@ function displayDatatableStudies(data, PAGE_TYPE, cleanBeforeInsert=true) {
         defaultNotVisible = true;
     }
 
+    var pub_date_help = '<span class="glyphicon glyphicon-question-sign" data-toggle="tooltip" ' +
+                                'data-container="body" title="Journal publication date YYYY-MM-DD"></span>'
+
 
     $('#study-table').bootstrapTable({
         exportDataType: 'all',
@@ -192,7 +195,7 @@ function displayDatatableStudies(data, PAGE_TYPE, cleanBeforeInsert=true) {
             filterControl: 'input'
         }, {
             field: 'publi',
-            title: 'Publication date',
+            title: 'Publication date '+pub_date_help,
             sortable: true,
             visible: defaultVisible,
             filterControl: 'input'


### PR DESCRIPTION
Added a help icon to the Publication date column in the Study table. It is also displayed in the Add/Remove column drop-down given this implementation.