### PR TITLE
Goci 2588 sn px snp interacton variant page fix

### DIFF
--- a/goci-interfaces/goci-ui/src/main/resources/static/js/generesult.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/generesult.js
@@ -223,6 +223,9 @@ function getEnsemblREST( URL )
         async: false,
         success: function(data) {
             result = data;
+        },
+        error: function(){
+            result = {'error' : request.responseText};
         }
     });
     return result;

--- a/goci-interfaces/goci-ui/src/main/resources/static/js/generesult.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/generesult.js
@@ -106,7 +106,6 @@ function getDataSolr(main, initLoad=false) {
             $('#lower_container').html("<h2>The Gene name <em>"+searchQuery+"</em> cannot be found in the GWAS Catalog database</h2>");
         }
         else {
-            console.log(slimData);
             processSolrData(data, initLoad, slimData); // gene name is now added to the process solr data function.
             //downloads link : utils-helper.js
             setDownloadLink(searchQuery);
@@ -271,7 +270,7 @@ function generateGeneInformationTable(slimData, studies) {
     }
 
     // Extracting cross-references:
-    var xrefQueryURL = gwasProperties.EnsemblRestBaseURL + '/xrefs/id/' + slimData.title + '?content-type=application/json'
+    var xrefQueryURL = gwasProperties.EnsemblRestBaseURL + '/xrefs/id/' + slimData.ensemblID + '?content-type=application/json'
     var xrefData = getEnsemblREST(xrefQueryURL);
     var entrezID = "NA";
     var OMIMID = "NA";

--- a/goci-interfaces/goci-ui/src/main/resources/static/js/generesult.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/generesult.js
@@ -86,8 +86,7 @@ function getDataSolr(main, initLoad=false) {
 
     // Step 1: returning list of variants mapped to the queried gene:
     var slimData = getSlimSolrData(searchQuery);
-    var mappedRsIDs = slimData.rsIDs;
-    console.log(mappedRsIDs.join(" OR "));
+    var mappedRsIDs = slimData.rsIDs.join(" OR ");
 
     return promisePost( gwasProperties.contextPath + 'api/search/advancefilter',
         {
@@ -148,22 +147,22 @@ function processSolrData(data, initLoad=false, slimData) {
     //TODO not repeat yourself!!!!
     $.each(data.grouped.resourcename.groups, (index, group) => {
         switch (group.groupValue) {
-    case "efotrait":
-        data_efo = group.doclist;
-        break;
-    case "study":
-        data_study = group.doclist;
-        break;
-    case "association":
-        data_association = group.doclist;
-        break;
-        //not sure we need this!
-    case "diseasetrait":
-        data_diseasetrait = group.doclist;
-        break;
-    default:
-    }
-});
+            case "efotrait":
+                data_efo = group.doclist;
+                break;
+            case "study":
+                data_study = group.doclist;
+                break;
+            case "association":
+                data_association = group.doclist;
+                break;
+                //not sure we need this!
+            case "diseasetrait":
+                data_diseasetrait = group.doclist;
+                break;
+            default:
+            }
+        });
     
     //remove association that annotated with efos which are not in the list
     var remove = Promise.resolve();
@@ -246,7 +245,7 @@ function generateGeneInformationTable(slimData, studies) {
     // adding gene data to html:
     $("#geneSymbol").html(slimData.title);
 
-    // Adding description related fields:
+    // Parsing description related fields:
     var descriptionFields = slimData.description.split("|");
     $("#description").html(descriptionFields[0])
     $("#location").html(descriptionFields[1]);
@@ -276,6 +275,7 @@ function generateGeneInformationTable(slimData, studies) {
     var xrefData = getEnsemblREST(xrefQueryURL);
     var entrezID = "NA";
     var OMIMID = "NA";
+    // If the request to Ensembl fails, the returned document will contain an error key:
     if (! "error" in xrefData){
         for ( xref of xrefData ){
             if ( xref.dbname == "EntrezGene" ){

--- a/goci-interfaces/goci-ui/src/main/resources/static/js/variantresult.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/variantresult.js
@@ -303,7 +303,7 @@ function getSlimSolrData(rsID) {
     }
     $.ajax({
         url: '../api/search',
-        data : {'q': "rsID:" + rsID + ' AND resourcename:variant'},
+        data : {'q': "rsID:\"" + rsID + '\" AND resourcename:variant'},
         type: 'get',
         dataType: 'json',
         async: false,

--- a/goci-interfaces/goci-ui/src/main/resources/static/js/variantresult.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/variantresult.js
@@ -168,52 +168,22 @@ function getSolrProperty(data, property) {
 }
 
 
-function getVariantInfo(data,rsId) {
-    var valid_index = getSolrProperty(data,'context');
-    var data_sample = data[valid_index];
+function getVariantInfo(data) {
 
-    if (data_sample.chromLocation) {
-        var location = data_sample.chromLocation[0];
-    }
+    // Retrieve variant info from the slim solr:
+    var rsId = $('#query').text();
+    var slimSolrData = getSlimSolrData(rsId);
+    var location = slimSolrData.position;
+    var consequence = slimSolrData.consequence;
+    var region = slimSolrData.region;
+    var mappedGenes = slimSolrData.mappedGenes;
 
-    if (data_sample.region) {
-        var region = data_sample.region[0];
-    }
-
-    if (data_sample.context) {
-        var func = data_sample.context[0];
-    }
-
-    var genes_mapped = [];
-    var genes_mapped_url = [];
+    // The following information is parsed from the fat solr:
     var traits_reported = [];
     var traits_reported_url = [];
     var all_mapped_traits = [];
-    $.each(data, function (index, doc) {
-        // Mapped genes
-        if (doc.hasOwnProperty('entrezMappedGenes')) {
-            var gene_list = [];
-            $.each(doc.entrezMappedGenes, function(index, gene) {
-                // check if "gene" contains multiple values, e.g. ["GCKR; GCKR"]
-                if (gene.indexOf(";") > 0) {
-                    gene_list = gene.split("; ");
 
-                    $.each(gene_list, function(index, split_gene) {
-                        if (jQuery.inArray(split_gene, genes_mapped) == -1) {
-                            genes_mapped.push(split_gene);
-                        }
-                    });
-                }
-                else {
-                    if (jQuery.inArray(gene, genes_mapped) == -1) {
-                        genes_mapped.push(gene);
-                        // remove link
-                        // genes_mapped_url.push(setQueryUrl(gene));
-                        genes_mapped_url.push(gene);
-                    }
-                }
-            });
-        }
+    $.each(data, function (index, doc) {
 
         // Mapped Traits
         var mapped_traits = doc.mappedLabel;
@@ -280,7 +250,6 @@ function getVariantInfo(data,rsId) {
             });
         }
     });
-    genes_mapped_url.sort();
     traits_reported_url.sort();
 
     // Reported Traits display
@@ -292,9 +261,12 @@ function getVariantInfo(data,rsId) {
     }
 
     // Location
-    if (jQuery.type(location) == 'undefined') {
+    if (location == 'NA:NA') {
         $("#variant-location").html('Variant does not map to the genome');
         $("._ld_graph").html('Variant does not map to the genome');
+        region = '-';
+        consequence = '-';
+        mappedGenes = ['-']
     }
     else {
         $("#variant-location").html(location);
@@ -305,16 +277,47 @@ function getVariantInfo(data,rsId) {
     $("#variant-region").html(region);
 
     // Most severe consequence
-    if (func) {
-        $("#variant-class").html(variationClassLabel(func));
-    }
+    $("#variant-class").html(consequence);
 
     // Mapped genes
-    if (genes_mapped_url.length != 0) {
-        $("#variant-mapped-genes").html(genes_mapped_url.join(', '));
+    if (mappedGenes.length != 0 && mappedGenes[0] != '-') {
+        mappedGeneLinks = [];
+        for ( gene of mappedGenes ){
+            var link = gwasProperties.contextPath + 'genes/' + gene
+            mappedGeneLinks.push(`<a href="${link}">${gene}</a>`);
+
+        }
+        $("#variant-mapped-genes").html(mappedGeneLinks.join(', '));
     }
 
     $("#variant-summary-content").html(getSummary(data));
+}
+
+// To overcome the inconsistencies in the fat solr, we retrieve variant data from the slim solr
+function getSlimSolrData(rsID) {
+    var returnData = {
+        'position' : '-',
+        'region': '-',
+        'consequence' : '-',
+        'mappedGenes' : []
+    }
+    $.ajax({
+        url: '../api/search',
+        data : {'q': "rsID:" + rsID + ' AND resourcename:variant'},
+        type: 'get',
+        dataType: 'json',
+        async: false,
+        success: function(data){
+            // Parse returned JSON;
+            var doc = data.response.docs[0];
+            returnData.position = doc.chromosomeName + ":" + doc.chromosomePosition;
+            returnData.region = doc.region;
+            returnData.consequence = doc.consequence;
+            returnData.mappedGenes = doc.description.split("|")[3].split(",")
+        }
+    });
+    console.log(returnData);
+    return returnData;
 }
 
 


### PR DESCRIPTION
This branch addresses 2 bugs:
* [GOCI-2588](https://www.ebi.ac.uk/panda/jira/browse/GOCI-2588) - The info panel of those variants which are involved in snp x snp interaction is now sorted out.
* [GOC-2612](https://www.ebi.ac.uk/panda/jira/browse/GOCI-2612) - variant and gene pages are made resilient to the failure of request sent to Ensembl REST API. Also whenever it's possible, we rather use the slim solr as source of information. 

Also as an extra feature, in the info panel of the variant page, the mapped genes are now linked to the corresponding gene pages.