### PR TITLE
add queryFilter to search to return matches to EFO term synoyms highe…

### DIFF
--- a/goci-interfaces/goci-ui/src/main/java/uk/ac/ebi/spot/goci/ui/controller/SolrSearchController.java
+++ b/goci-interfaces/goci-ui/src/main/java/uk/ac/ebi/spot/goci/ui/controller/SolrSearchController.java
@@ -74,10 +74,16 @@ public class SolrSearchController {
         else {
             addRowsAndPage(solrSearchBuilder, maxResults, page);
         }
+        addQueryFilter(solrSearchBuilder);
         addQuery(solrSearchBuilder, query);
 
         // dispatch search
         dispatchSearch(solrSearchBuilder.toString(), response.getOutputStream());
+    }
+
+    // Use queryFilter to return match to term synonym higher in the result list
+    private void addQueryFilter(StringBuilder solrSearchBuilder) {
+        solrSearchBuilder.append("&defType=dismax&qf=title%5E2.0+synonyms%5E20.0+parent%5E2.0+text%5E1.0");
     }
 
 


### PR DESCRIPTION
The goal of this update is to return matches to EFO term synonyms higher in the result list, i.e. return a match to a trait snippet with a match to a synonym before another document type. This is not a perfect fix, but is better than what is currently on Prod. The dircect Solr results were reviewed with ES and found to be better and worthwhile to add this update.

Example search terms: breast carcinoma, breast cancer