### PR TITLE
change search result and main page.

### DIFF
--- a/goci-interfaces/goci-ui/src/main/resources/static/js/solrsearch.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/solrsearch.js
@@ -665,7 +665,7 @@ function setStats(data) {
         $('#releasedate-stat').text("Last data release on " + data.date);
         $('#studies-stat').text(data.studies + " publications");
         $('#snps-stat').text(data.snps + " SNPs");
-        $('#associations-stat').text(data.associations + " unique SNP-trait associations");
+        $('#associations-stat').text(data.associations + " associations");
         $('#genomebuild').text("Genome assembly " + data.genebuild);
         $('#dbsnpbuild').text("dbSNP Build " + data.dbsnpbuild);
         $('#ensemblbuild').text("Ensembl Build " + data.ensemblbuild);

--- a/goci-interfaces/goci-ui/src/main/resources/templates/index.html
+++ b/goci-interfaces/goci-ui/src/main/resources/templates/index.html
@@ -106,7 +106,7 @@
     </div>
 
     <div class="row" style="text-align: center" id="homepageStats">
-       <p> As of <span id="lastUpdateDate"></span>, the GWAS Catalog contains <span id="studyCount"></span> publications and <span id="associationCount"></span> unique SNP-trait associations.<br/> GWAS Catalog data is currently mapped to Genome Assembly <span id="genomeAssembly"></span> and dbSNP Build <span id="dbSNP"></span>.</p>
+       <p> As of <span id="lastUpdateDate"></span>, the GWAS Catalog contains <span id="studyCount"></span> publications and <span id="associationCount"></span> associations.<br/> GWAS Catalog data is currently mapped to Genome Assembly <span id="genomeAssembly"></span> and dbSNP Build <span id="dbSNP"></span>.</p>
     </div>
 
     <div class="row" style="text-align: center">


### PR DESCRIPTION
Addressing GOCI-2667, the stats text is changed on the main page and on the search result page. Once we have implemented the improved trait representation, we might want to review the stats panels to provide a potentially more informative measures. 

This branch was deployed to dev2 and was reviewed by Maria and Jackie.