### PR TITLE
add parameter to search so dismax is used only with general text search queries

### DIFF
--- a/goci-interfaces/goci-ui/src/main/java/uk/ac/ebi/spot/goci/ui/controller/SolrSearchController.java
+++ b/goci-interfaces/goci-ui/src/main/java/uk/ac/ebi/spot/goci/ui/controller/SolrSearchController.java
@@ -60,6 +60,7 @@ public class SolrSearchController {
     @CrossOrigin
     public void doSolrSearch(
             @RequestParam("q") String query,
+            @RequestParam(value = "generalTextQuery", required=false, defaultValue = "false") boolean generalTextQuery,
             @RequestParam(value = "jsonp", required = false, defaultValue = "false") boolean useJsonp,
             @RequestParam(value = "callback", required = false) String callbackFunction,
             @RequestParam(value = "max", required = false, defaultValue = "1000") int maxResults,
@@ -74,7 +75,10 @@ public class SolrSearchController {
         else {
             addRowsAndPage(solrSearchBuilder, maxResults, page);
         }
-        addQueryFilter(solrSearchBuilder);
+
+        if (generalTextQuery) {
+            addQueryFilter(solrSearchBuilder);
+        }
         addQuery(solrSearchBuilder, query);
 
         // dispatch search

--- a/goci-interfaces/goci-ui/src/main/resources/static/js/solrsearch.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/solrsearch.js
@@ -153,7 +153,7 @@ function solrSearch(queryTerm) {
         var boost_field = ' OR title:"'.concat(queryTerm).concat('"')+' OR synonyms:"'.concat(queryTerm).concat('"');
         var searchPhrase = searchTerm.concat(boost_field);
 
-        $.getJSON('api/search', {'q': searchPhrase})
+        $.getJSON('api/search', {'q': searchPhrase, 'generalTextQuery': true})
             .done(function(data) {
                 console.log(data);
                 processData(data);


### PR DESCRIPTION
Added a parameter to "text" queries so that only these include the "dismax" queryFilter parameter so that the other searches work as previously designed.