### PR TITLE
Fixing bug if no efo short form is present in the solr

### DIFF
--- a/goci-interfaces/goci-ui/src/main/resources/static/js/common-datatables/efotraits-datatable.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/common-datatables/efotraits-datatable.js
@@ -113,7 +113,22 @@ function preprocessData(data) {
     $.each(data, function (index, association_doc) {
 
         var efo_trait_data = {};
-        var efo_id = association_doc.shortForm.sort();
+        // This block is to keep track of EFO term combinations:
+        var efo_id = [];
+        if (association_doc.hasOwnProperty('shortForm')){
+            efo_id = association_doc.shortForm.sort();
+        }
+        else if (association_doc.hasOwnProperty('mappedUri')){
+            var shortenedUri = [];
+            for( var uri of association_doc.mappedUri){
+                shortenedUri.push(uri.split("/").slice(-1)[0]);
+            }
+            efo_id = shortenedUri.sort();
+        }
+        else{
+            console.log("[Warning] No efo short form or trait uri is present in the returned solr document!");
+            return;
+        }
 
         // join EFO Id to form unique key
         var efo_id_key = efo_id.join("_");


### PR DESCRIPTION
This modification supposed to deal with cases when the solr document doesn't have EFO `shortForm`. In that case, the `mapedUri` is used and parsed the short form out of it. If that is also missing, the document is skipped. 

As the `mappedUri` is seemingly always there, we can just use that? Anyways, curators have verified this modification.