### PR TITLE
fix location order

### DIFF
--- a/goci-interfaces/goci-ui/src/main/resources/static/js/common-datatables/associations-datatable.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/common-datatables/associations-datatable.js
@@ -186,7 +186,7 @@ function displayDatatableAssociations(data, cleanBeforeInsert) {
 
                     // Test if the mapping is on a chromosome:
                     if ( chrom.length < 3 ){
-                        parsedPositions.unshift(chrom + ':' + bpLocation)
+                        parsedPositions.push(chrom + ':' + bpLocation)
                     }
                 })
 


### PR DESCRIPTION
Instead adding the new position value to the beginning of an array, it is now added to the end. So the order of the positions will reflect the order of the variants. jira issue: https://www.ebi.ac.uk/panda/jira/browse/GOCI-2784 