### PR TITLE
Adding link to survey

### DIFF
--- a/goci-interfaces/goci-ui/src/main/resources/templates/index.html
+++ b/goci-interfaces/goci-ui/src/main/resources/templates/index.html
@@ -53,7 +53,7 @@
     <div class="row" style="text-align: center">
             <p></p>
 
-        <a href="https://youtu.be/4FplAQzRfh8" target="_blank"><h2 class="color-primary-bold">Take a tour of the NEW search interface...</h2></a>
+        <a href="https://www.surveymonkey.co.uk/r/GWASCatalog_assoc" target="_blank"><h2 class="color-primary-bold">Complete our user survey - How important is replication information in the associations we present?</h2></a>
 
     </div>
     <div class="row">


### PR DESCRIPTION
This modification is very minor, only updates the link on the front page:
* The link pointing to the take a tour youtube video is removed
* A link pointing to the GWAS survey is added instead.