### PR TITLE
Goci 2803 ds study table uses efo link if present

### DIFF
--- a/goci-interfaces/goci-ui/src/main/resources/static/js/common-datatables/associations-datatable.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/common-datatables/associations-datatable.js
@@ -162,16 +162,17 @@ function displayDatatableAssociations(data, cleanBeforeInsert) {
             }
 
             // Mapped traits
-            var mappedTraits = asso.mappedLabel;
-            if (mappedTraits) {
-                $.each(mappedTraits, function (index, trait) {
-                    var link = gwasProperties.contextPath + 'efotraits/' + asso.mappedUri[index].split('/').slice(-1)[0]
-                    mappedTraits[index] = setInternalLinkText(link, trait);
-                });
-                tmp['mappedTraits'] = mappedTraits.join(', ');
-            } else {
-                tmp['mappedTraits'] = '-';
-            }
+            tmp['mappedTraits'] = setTraitsLink(asso);
+            // var mappedTraits = asso.mappedLabel;
+            // if (mappedTraits) {
+            //     $.each(mappedTraits, function (index, trait) {
+            //         var link = gwasProperties.contextPath + 'efotraits/' + asso.mappedUri[index].split('/').slice(-1)[0]
+            //         mappedTraits[index] = setInternalLinkText(link, trait);
+            //     });
+            //     tmp['mappedTraits'] = mappedTraits.join(', ');
+            // } else {
+            //     tmp['mappedTraits'] = '-';
+            // }
 
             // Adding genomic location to the table (but excluding mappings to patch regions)
             var genomicCoordinate = 'Mapping not available';

--- a/goci-interfaces/goci-ui/src/main/resources/static/js/common-datatables/associations-datatable.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/common-datatables/associations-datatable.js
@@ -163,16 +163,6 @@ function displayDatatableAssociations(data, cleanBeforeInsert) {
 
             // Mapped traits
             tmp['mappedTraits'] = setTraitsLink(asso);
-            // var mappedTraits = asso.mappedLabel;
-            // if (mappedTraits) {
-            //     $.each(mappedTraits, function (index, trait) {
-            //         var link = gwasProperties.contextPath + 'efotraits/' + asso.mappedUri[index].split('/').slice(-1)[0]
-            //         mappedTraits[index] = setInternalLinkText(link, trait);
-            //     });
-            //     tmp['mappedTraits'] = mappedTraits.join(', ');
-            // } else {
-            //     tmp['mappedTraits'] = '-';
-            // }
 
             // Adding genomic location to the table (but excluding mappings to patch regions)
             var genomicCoordinate = 'Mapping not available';

--- a/goci-interfaces/goci-ui/src/main/resources/static/js/common-datatables/studies-datatable.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/common-datatables/studies-datatable.js
@@ -209,16 +209,7 @@ function prepareDataForTable(data){
         tmp['reported_trait'] = study.traitName_s;
 
         // Mapped trait:
-        var mappedTraits = study.mappedLabel;
-        if (mappedTraits) {
-            $.each(mappedTraits, function(index, trait) {
-                var link = gwasProperties.contextPath + 'efotraits/' + study.mappedUri[index].split('/').slice(-1)[0];
-                mappedTraits[index] = setInternalLinkText(link, trait);
-            });
-            tmp['mappedTraits'] = mappedTraits.join(', ');
-        } else {
-            tmp['mappedTraits'] = '-';
-        }
+        tmp['mappedTraits'] = setTraitsLink(study);
 
         // Initial sample desc
         var splitDescription = [];

--- a/goci-interfaces/goci-ui/src/main/resources/static/js/helpers/utils-helper.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/helpers/utils-helper.js
@@ -110,6 +110,43 @@ function displayArrayAsList(data_array) {
     return data_text;
 }
 
+/*
+The mapped trait links are extracted from efoLink if that is present. If not, mappedLabel and mappedUri is used as
+source of information.
+ */
+function setTraitsLink(study) {
+
+    // A collection of EFO trait labels and the corresponding short links:
+    var efoLabelUriPairs = {};
+
+    // Formatted links to trait pages:
+    var efoTraitLinks = [];
+
+    // Check if the efoUri exists:
+    if ('efoLink' in study){
+        $.each(study.efoLink, function (index, efoLink) {
+            var label = efoLink.split("|")[0];
+            var link = efoLink.split("|")[1];
+            efoLabelUriPairs[label] = link;
+        });
+    }
+    // If efoUri does not exists, use mappedLabel and mappedUri instead
+    else {
+        $.each(study.mappedLabel, function (index, label) {
+            var link = study.mappedUri[index].split("/").pop();
+            efoLabelUriPairs[label] = link;
+        });
+    }
+
+    // Generating links to mapped trait labels:
+    $.each(efoLabelUriPairs, function (label, link) {
+        var traitPageLink = gwasProperties.contextPath + 'efotraits/' + link;
+        efoTraitLinks.push(setExternalLinkText(traitPageLink, label));
+    });
+
+    return efoTraitLinks.join(",");
+}
+
 
 // Display the Ancestry array as a HTML list
 function displayAncestryLinksAsList(data_array) {

--- a/goci-interfaces/goci-ui/src/main/resources/static/js/studyresult.js
+++ b/goci-interfaces/goci-ui/src/main/resources/static/js/studyresult.js
@@ -184,7 +184,6 @@ function displaySummaryStudy(data, clearBeforeInsert) {
     $("#study-pubmedid").html(pubmedIdLink);
     $("#study-datepublication").html(study.publicationDate.split('T')[0]);
     if ('authorsList' in study) {
-        console.log(study.authorsList);
         // require toggle-resize.js
         var reduce_text= displayAuthorsListAsList(study.authorsList);
         reduce_text = addShowMoreLink(reduce_text, 500, "...");
@@ -261,21 +260,6 @@ function getGenotypingTech(study) {
     return genotypingTechnologiesList;
 }
 
-
-function setTraitsLink(study) {
-    var mappedTraits="";
-    var mappedTraits = study.mappedLabel;
-    if (mappedTraits) {
-        $.each(mappedTraits, function (index, trait) {
-            var link = gwasProperties.contextPath + 'efotraits/' + study.mappedUri[index].split('/').slice(-1)[0];
-            mappedTraits[index] = setExternalLinkText(link, trait);
-        });
-        mappedTraits = mappedTraits.join(', ');
-    } else {
-        mappedTraits = '-';
-    }
-    return mappedTraits;
-}
 
 function setAncentrySection(study) {
     var pubdate = study.publicationDate.substring(0, 10);

--- a/goci-interfaces/goci-ui/src/main/resources/templates/index.html
+++ b/goci-interfaces/goci-ui/src/main/resources/templates/index.html
@@ -53,7 +53,7 @@
     <div class="row" style="text-align: center">
             <p></p>
 
-        <a href="https://www.surveymonkey.co.uk/r/GWASCatalog_assoc" target="_blank"><h2 class="color-primary-bold">Complete our user survey - How important is replication information in the associations we present?</h2></a>
+        <a href="https://www.surveymonkey.co.uk/r/GSW52MW" target="_blank"><h2 class="color-primary-bold">Complete our user survey - How important is replication information in the associations we present?</h2></a>
 
     </div>
     <div class="row">


### PR DESCRIPTION
This branch deals with associations/studies where the assigned EFO trait was not in OLS upon the data release. In these cases the trait values are extracted from those solr fields that were stored in the database. See more information under the ticket.