### PR TITLE
remove efotrait-utils.js from publication page. Otherwise data loaded…

### DIFF
--- a/goci-interfaces/goci-ui/src/main/resources/templates/publication-page.html
+++ b/goci-interfaces/goci-ui/src/main/resources/templates/publication-page.html
@@ -235,7 +235,7 @@
     <script th:src="@{/js/common-datatables/associations-datatable.js}"></script>
     <script th:src="@{/js/common-datatables/studies-datatable.js}"></script>
 
-    <script th:src="@{/js/efotrait-util.js}"></script>
+    <!--<script th:src="@{/js/efotrait-util.js}"></script>-->
     <script th:src="@{/js/autocomplete-termselect.js}"></script>
     <script th:src="@{/js/jquery.autocomplete.js}"></script>
 


### PR DESCRIPTION
We have noticed that the solr data fetched from the server twice on the publication page. It was due to the unnecessary loading of `efotrait_utils.js` file. 